### PR TITLE
Create the plausible stats shortcode

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -47,6 +47,10 @@ doNotLoadAnimations = false
 # listDateFormat = "Jan 2"
 # singleDateFormat = "Mon, Jan 2, 2006"
 
+# OpenFaaS domain
+[params.openfaas]
+domain = "https://faasd.ptco.rocks/function"
+
 [params.simpleAnalytics]
 # enable = true
 # customurl = "https://analytics.example.com"

--- a/content/retrospectives/2021/03/index.md
+++ b/content/retrospectives/2021/03/index.md
@@ -177,6 +177,13 @@ and [Mudmap].
 - Write a blog post about pfSense
 - Increase Mudmap's marketing
 
+## Analytics
+
+{{< plausible start=2021-03-01 end=2021-03-31 site_id=mudmap.io >}}
+
+{{< plausible start=2021-03-01 end=2021-03-31 site_id=danielms.site >}}
+
+
 [mudmap]: https://mudmap.io?ref=danielms.site
 [danielms]: https://danielms.site?ref=danielms.site
 [whatgotdone]: https://whatgotdone.com

--- a/content/retrospectives/2021/04/index.md
+++ b/content/retrospectives/2021/04/index.md
@@ -151,6 +151,17 @@ For a great introduction, see this Tweet.
 - Start the documentation pages
 - Replace the pricing page, and if possible, embed it in Hugo as a React component
 
+## Analytics
+
+{{< plausible start=2021-04-01 end=2021-04-30 site_id=mudmap.io >}}
+
+
+{{< plausible start=2021-04-01 end=2021-04-30 site_id=check-redirects.com >}}
+
+
+{{< plausible start=2021-04-01 end=2021-04-30 site_id=danielms.site >}}
+
+
 [mudmap]: https://mudmap.io/?utm_campaign=retro&utm_source=danielms&utm_medium=blog
 [paddle]: https://paddle.com
 [netlify]: https://netlify.com

--- a/content/retrospectives/2021/05/index.md
+++ b/content/retrospectives/2021/05/index.md
@@ -167,18 +167,22 @@ Second!
 
 ![mudmap google](google-rank.png "Google ranking for Mudmap")
 
-### Analytics
-
-For a bit of transparency, this month's analytics.
-
-![mudmap plausible metrics](analytics-mm-may.png "Analytics for Mudmap.io")
-
 ## Next month's goals
 
 - Add a Rule set feature to Mudmap
 - Email 5 prospects
 - Reinvigorate an old project that I plan to monetize (long term SEO play now for reward later)
 
+
+## Analytics
+
+{{< plausible start=2021-05-01 end=2021-05-31 site_id=mudmap.io >}}
+
+
+{{< plausible start=2021-05-01 end=2021-05-31 site_id=check-redirects.com >}}
+
+
+{{< plausible start=2021-05-01 end=2021-05-31 site_id=danielms.site >}}
 
 [mudmap]: https://mudmap.io/?utm_campaign=retro-may-21&utm_source=danielms&utm_medium=blog
 [docs]: https://docs.mudmap.io/

--- a/content/retrospectives/2021/06/index.md
+++ b/content/retrospectives/2021/06/index.md
@@ -128,14 +128,14 @@ I put this here for my future reference.
 
 ![my twitter june](twit-june-2021.png "Daniel Michaels twitter analytics for June 2021")
 
-**Mudmap**
 
-![mudmap analytics](mm-june-pstats.png "Mudmap's plausible stats for June 2021")
+{{< plausible start=2021-06-01 end=2021-06-30 site_id=mudmap.io >}}
 
-**Check Redirects**
 
-![Check Redirects analytics](cr-june-pstats.png "Check Redirects' plausible stats for June 2021")
+{{< plausible start=2021-06-01 end=2021-06-30 site_id=check-redirects.com >}}
 
+
+{{< plausible start=2021-06-01 end=2021-06-30 site_id=danielms.site >}}
 
 ## Next months goals
 

--- a/content/retrospectives/2021/07/index.md
+++ b/content/retrospectives/2021/07/index.md
@@ -187,13 +187,15 @@ I'm looking forward to August and producing more content for users of Mudmap to 
 
 ## Analytics
 
-**Mudmap**
 
-![](mm-july-plausible-stats.png 'Mudmap plausible stats for July 2021')
+{{< plausible start=2021-07-01 end=2021-07-31 site_id=mudmap.io >}}
 
-**Check-Redirects**
 
-![](cr-plausible-stats-jul-2021.png 'Check-Redirects.com plausible stats for July 2021')
+{{< plausible start=2021-07-01 end=2021-07-31 site_id=check-redirects.com >}}
+
+
+{{< plausible start=2021-07-01 end=2021-07-31 site_id=danielms.site >}}
+
 
 **Twitter**
 

--- a/content/retrospectives/2021/08/index.md
+++ b/content/retrospectives/2021/08/index.md
@@ -141,13 +141,14 @@ Repeating this month's goals.
 
 ## Analytics
 
-**Mudmap**
+{{< plausible start=2021-08-01 end=2021-08-30 site_id=mudmap.io >}}
 
-![](plausible-aug.png 'Mudmap plausible stats for August 2021')
 
-**Check-Redirects**
+{{< plausible start=2021-08-01 end=2021-08-30 site_id=check-redirects.com >}}
 
-![](cr-plausible-aug.png 'Check-Redirects.com plausible stats for August 2021')
+
+{{< plausible start=2021-08-01 end=2021-08-30 site_id=danielms.site >}}
+
 
 **Twitter**
 

--- a/content/retrospectives/2021/09/index.md
+++ b/content/retrospectives/2021/09/index.md
@@ -112,13 +112,14 @@ to just experiment.
 
 ## Analytics
 
-**Mudmap**
+{{< plausible start=2021-09-01 end=2021-09-30 site_id=mudmap.io >}}
 
-![](mm-sept-stats.png 'Mudmap plausible stats for September 2021')
 
-**Check-Redirects**
+{{< plausible start=2021-09-01 end=2021-09-30 site_id=check-redirects.com >}}
 
-![](cr-sept-stats.png 'Check-Redirects.com plausible stats for September 2021')
+
+{{< plausible start=2021-09-01 end=2021-09-30 site_id=danielms.site >}}
+
 
 **Twitter**
 

--- a/content/retrospectives/2021/10/index.md
+++ b/content/retrospectives/2021/10/index.md
@@ -136,13 +136,13 @@ and emotional space to take stock of a few things.
 
 ## Analytics
 
-**Mudmap**
 
-![](mm-oct.png 'Mudmap plausible stats for September 2021')
+{{< plausible start=2021-10-01 end=2021-10-31 site_id=mudmap.io >}}
 
-**Check-Redirects**
 
-![](cr-oct.png 'Check-Redirects.com plausible stats for September 2021')
+{{< plausible start=2021-10-01 end=2021-10-31 site_id=check-redirects.com >}}
+
+{{< plausible start=2021-10-01 end=2021-10-31 site_id=danielms.site >}}
 
 **Twitter**
 

--- a/content/retrospectives/2021/11/index.md
+++ b/content/retrospectives/2021/11/index.md
@@ -131,17 +131,13 @@ feel much more motivated.
 
 ## Analytics
 
-**Mudmap**
+{{< plausible start=2021-11-01 end=2021-11-30 site_id=mudmap.io >}}
 
-![](mm-nov-retro.png 'Mudmap plausible stats for November 2021')
 
-**Check-Redirects**
+{{< plausible start=2021-11-01 end=2021-11-30 site_id=check-redirects.com >}}
 
-![](cr-nov-retro.png 'Check-Redirects.com plausible stats for November 2021')
 
-**danielms.site**
-
-![](danielms-nov-retro.png 'danielms.site plausible stats for November 2021')
+{{< plausible start=2021-11-01 end=2021-11-30 site_id=danielms.site >}}
 
 **Twitter**
 

--- a/content/retrospectives/2021/12/index.md
+++ b/content/retrospectives/2021/12/index.md
@@ -110,17 +110,14 @@ It's been a big year with lots ups and downs, wasted efforts, and successes.
 
 ## Analytics
 
-**Mudmap**
+{{< plausible start=2021-12-01 end=2021-12-31 site_id=mudmap.io >}}
 
-![](mm-dec-21.png 'Mudmap plausible stats for December 2021')
 
-**Check-Redirects**
+{{< plausible start=2021-12-01 end=2021-12-31 site_id=check-redirects.com >}}
 
-![](cr-dec-21.png 'Check-Redirects.com plausible stats for December 2021')
 
-**danielms.site**
+{{< plausible start=2021-12-01 end=2021-12-31 site_id=danielms.site >}}
 
-![](danms-dec-21.png 'danielms.site plausible stats for December 2021')
 
 [comment]: <> (**Twitter**)
 

--- a/content/retrospectives/retro-template.md
+++ b/content/retrospectives/retro-template.md
@@ -59,4 +59,14 @@ anything interesting that I have found, seen, listened to or created that **prov
 - two
 - three goals
 
+## Analytics 
+
+{{< plausible start=2021-11-01 end=2021-11-30 site_id=mudmap.io >}}
+
+
+{{< plausible start=2021-11-01 end=2021-11-30 site_id=check-redirects.com >}}
+
+
+{{< plausible start=2021-11-01 end=2021-11-30 site_id=danielms.site >}}
+
 [mudmap]: https://mudmap.io/?utm_campaign=retro&utm_source=danielms&utm_medium=blog

--- a/layouts/shortcodes/plausible.html
+++ b/layouts/shortcodes/plausible.html
@@ -50,7 +50,7 @@
                     data: {
                         labels: dates,
                         datasets: [{
-                            label: site_id,
+                            label: "Visitors",
                             data: visitors,
                             backgroundColor: "rgba(255, 99, 132, 0.2)",
                             borderColor: "rgba(255, 99, 132, 1)",
@@ -82,14 +82,13 @@
                 })
             }).catch(err => console.log("failed to retrieve plausible stats", err))
         })()
-
         function generateTableHead(table, data) {
             function toTitleCase(str) {
                 return str.replace(
-                  /\w\S*/g,
-                  function(txt) {
-                    return txt.charAt(0).toUpperCase() + txt.substr(1).toLowerCase();
-                  }
+                    /\w\S*/g,
+                    function(txt) {
+                        return txt.charAt(0).toUpperCase() + txt.substr(1).toLowerCase();
+                    }
                 );
             }
             let thead = table.createTHead();
@@ -101,14 +100,25 @@
                 row.appendChild(th);
             }
         }
-
         function generateTable(table, data) {
+            function fmtMSS(s){return(s-(s%=60))/60+(9<s?':':':0')+s}
             for (let element of data) {
                 let row = table.insertRow();
                 for (const key in element) {
+                    console.log(key)
                     let cell = row.insertCell();
-                    let text = document.createTextNode(element[key].value);
-                    cell.appendChild(text);
+                    if (key === 'bounce_rate') {
+                        let val = element[key].value + " %"
+                        let text = document.createTextNode(val);
+                        cell.appendChild(text);
+                    } else if (key === 'visit_duration') {
+                        let val = fmtMSS(element[key].value)
+                        let text = document.createTextNode(val);
+                        cell.appendChild(text);
+                    } else {
+                        let text = document.createTextNode(element[key].value);
+                        cell.appendChild(text);
+                    }
                 }
             }
         }

--- a/layouts/shortcodes/plausible.html
+++ b/layouts/shortcodes/plausible.html
@@ -1,0 +1,116 @@
+<div>
+    <h3>{{ .Get "site_id" }}
+    </h3>
+    <div id="plausible-table">
+        <table id='table-{{ .Get "site_id" }}'></table>
+        <div>
+            <canvas id='{{ .Get "site_id"}}-Chart' width="200"
+                    height="200"></canvas>
+        </div>
+    </div>
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/Chart.js/3.7.0/chart.min.js"></script>
+    <script type="application/javascript">
+        // Calling the API and rendering the Chart are done inside a single
+        // IIFE so that no function name duplicate declaration errors occur.
+        // This shortcode is designed to be called multiple times within a
+        // single page.
+        (() => {
+            let domain = {{ .Site.Params.openfaas.domain}}
+            let site_id = {{ .Get "site_id" }}
+            let start_date = {{ .Get "start" }}
+            let end_date = {{ .Get "end" }}
+            const payload = {
+                site_id: site_id,
+                start_date: start_date,
+                end_date: end_date
+            }
+            fetch(`${domain}/plausible`, {
+                method: "POST",
+                body: JSON.stringify(payload)
+            }).then(data => {
+                return data.json()
+            }).then(resp => {
+                let table = document.getElementById('table-{{ .Get "site_id" }}')
+                let aggregate = [resp.aggregate.results]
+                let data = Object.keys(aggregate[0])
+                generateTableHead(table, data)
+                generateTable(table, aggregate)
+
+                let result = resp.timeseries.results
+                
+                let dates = []
+                result.forEach(elem => dates.push(elem.date))
+
+                let visitors = []
+                result.forEach(elem => visitors.push(elem.visitors))
+                
+                const ctx = '{{ .Get "site_id" }}-Chart'
+                new Chart(ctx, {
+                    type: "line",
+                    data: {
+                        labels: dates,
+                        datasets: [{
+                            label: site_id,
+                            data: visitors,
+                            backgroundColor: "rgba(255, 99, 132, 0.2)",
+                            borderColor: "rgba(255, 99, 132, 1)",
+                            borderWidth: 1,
+                            fill: true,
+                            tension: 0.3,
+                        }]
+                    },
+                    options: {
+                        responsive: true,
+                        maintainAspectRatio: false,
+                        plugins: {
+                            tooltip: {
+                                callbacks: {
+                                    label: function (context) {
+                                        let label = "visitors"
+                                        if (label) {
+                                            label += ': ';
+                                        }
+                                        if (context.parsed.y !== null) {
+                                            label += context.parsed.y
+                                        }
+                                        return label;
+                                    }
+                                }
+                            }
+                        }
+                    }
+                })
+            }).catch(err => console.log("failed to retrieve plausible stats", err))
+        })()
+
+        function generateTableHead(table, data) {
+            function toTitleCase(str) {
+                return str.replace(
+                  /\w\S*/g,
+                  function(txt) {
+                    return txt.charAt(0).toUpperCase() + txt.substr(1).toLowerCase();
+                  }
+                );
+            }
+            let thead = table.createTHead();
+            let row = thead.insertRow();
+            for (let key of data) {
+                let th = document.createElement("th");
+                let text = document.createTextNode(toTitleCase(key.replace('_', ' ')));
+                th.appendChild(text);
+                row.appendChild(th);
+            }
+        }
+
+        function generateTable(table, data) {
+            for (let element of data) {
+                let row = table.insertRow();
+                for (const key in element) {
+                    let cell = row.insertCell();
+                    let text = document.createTextNode(element[key].value);
+                    cell.appendChild(text);
+                }
+            }
+        }
+    </script>
+</div>


### PR DESCRIPTION
# Plausible Hugo Shortcode

This shortcode is used to display a time series and aggregate summary of a given Plausible websites montly analytics.

The shortcode usage:
    `{{< plausible start=2022-01-01 end=2022-01-31 site_id=danielms.site >}}`

Date times must be in `2022-01-01` format - this is what Plausible expects. 

This will render the site analytics with a Chart.js line graph and aggregate analytics data above the chart.

The site_id must match exactly with plausible's entry - case sensitive.